### PR TITLE
Harness: wire lurkers + Promise.allSettled spawn

### DIFF
--- a/src/sim/harness.ts
+++ b/src/sim/harness.ts
@@ -45,22 +45,51 @@ export class Harness {
 
     this.scraper.start();
     const authors: Author[] = [];
-    let counter = 0;
+    const lurkers: Author[] = [];
+    let authorCounter = 0;
+    let droppedAuthorsTotal = 0;
+
+    const spawn = async (
+      kind: 'author' | 'lurker',
+      count: number,
+      indexBase: number,
+    ): Promise<{live: Author[]; dropped: number}> => {
+      const candidates = Array.from({length: count}, (_, i) => factory({
+        url: this.cfg.sutUrl,
+        padId: this.cfg.padId ?? 'loadtest',
+        authorName: `${kind === 'lurker' ? 'l' : 'a'}${indexBase + i + 1}`,
+        editIntervalMs: this.cfg.editIntervalMs,
+      }));
+      const results = await Promise.allSettled(candidates.map((a) => a.connect()));
+      const live: Author[] = [];
+      let dropped = 0;
+      results.forEach((r, i) => {
+        if (r.status === 'fulfilled') live.push(candidates[i]!);
+        else dropped++;
+      });
+      return {live, dropped};
+    };
 
     try {
+      // Lurkers: spawn once at the start, never start(), hold sockets across the sweep.
+      if (this.cfg.lurkers > 0) {
+        const {live, dropped} = await spawn('lurker', this.cfg.lurkers, 0);
+        lurkers.push(...live);
+        droppedAuthorsTotal += dropped; // attributed to first step below
+      }
+
       for (let n = sweep.min; n <= sweep.max; n += sweep.step) {
         const delta = n - authors.length;
-        for (let i = 0; i < delta; i++) {
-          const a = factory({
-            url: this.cfg.sutUrl,
-            padId: this.cfg.padId ?? 'loadtest',
-            authorName: `a${++counter}`,
-            editIntervalMs: this.cfg.editIntervalMs,
-          });
-          await a.connect();
-          a.start();
-          authors.push(a);
+        let stepDropped = 0;
+        if (delta > 0) {
+          const {live, dropped} = await spawn('author', delta, authorCounter);
+          authorCounter += delta;
+          for (const a of live) { a.start(); authors.push(a); }
+          stepDropped = dropped;
         }
+        // Lurker connect failures roll into the first step that records them, so the
+        // curve's first row reflects total concurrency shortfall, not a silent miss.
+        if (droppedAuthorsTotal > 0) { stepDropped += droppedAuthorsTotal; droppedAuthorsTotal = 0; }
         // warmup
         await sleep(sweep.warmupMs);
         for (const a of authors) a.drainSamples();
@@ -79,7 +108,7 @@ export class Harness {
           latencyMs: summary,
           throughputCsps,
           snapshot,
-          droppedAuthors: 0,
+          droppedAuthors: stepDropped,
           errors,
           breakageFlags,
           samples: this.cfg.report.keepRawSamples ? samples : null,
@@ -89,6 +118,7 @@ export class Harness {
       }
     } finally {
       for (const a of authors) await a.stop();
+      for (const l of lurkers) await l.stop();
       await this.scraper.stop();
     }
 

--- a/tests/sim/harness.test.ts
+++ b/tests/sim/harness.test.ts
@@ -10,18 +10,31 @@ import type {Sample} from '../../src/sim/types.js';
 
 class StubAuthor extends EventEmitter {
   static instances: StubAuthor[] = [];
+  static failNext = 0; // next N connect() calls will reject
+  started = false;
+  stopped = false;
+  authorName: string;
   private samples: Sample[] = [];
   private errs = 0;
-  constructor() { super(); StubAuthor.instances.push(this); }
-  async connect(): Promise<void> {}
-  start(): void {}
-  async stop(): Promise<void> {}
+  constructor(authorName = 't') {
+    super();
+    this.authorName = authorName;
+    StubAuthor.instances.push(this);
+  }
+  async connect(): Promise<void> {
+    if (StubAuthor.failNext > 0) {
+      StubAuthor.failNext--;
+      throw new Error('stub connect failure');
+    }
+  }
+  start(): void { this.started = true; }
+  async stop(): Promise<void> { this.stopped = true; }
   drainSamples(): Sample[] { const o = this.samples; this.samples = []; return o; }
   getErrors(): number { return this.errs; }
   /** Test helper: push synthetic samples. */
   inject(ms: number, n = 1): void {
     for (let i = 0; i < n; i++) {
-      this.samples.push({authorId: 't', sentAtNs: 0n, ackedAtNs: 0n, latencyMs: ms});
+      this.samples.push({authorId: this.authorName, sentAtNs: 0n, ackedAtNs: 0n, latencyMs: ms});
     }
   }
 }
@@ -34,9 +47,11 @@ class StubScraper {
   }
 }
 
+const resetStubs = (): void => { StubAuthor.instances = []; StubAuthor.failNext = 0; };
+
 describe('Harness.run sweep', () => {
   it('produces one StepResult per swept step, with percentiles from drained samples', async () => {
-    StubAuthor.instances = [];
+    resetStubs();
     vi.useFakeTimers();
     const dir = mkdtempSync(join(tmpdir(), 'h-'));
     try {
@@ -45,7 +60,7 @@ describe('Harness.run sweep', () => {
         sweep: {axis: 'authors', min: 1, max: 2, step: 1, warmupMs: 10, dwellMs: 20},
       });
       const h = new Harness(cfg, new StubScraper() as never,
-                            { authorFactory: () => new StubAuthor() as never });
+                            { authorFactory: (o) => new StubAuthor(o.authorName) as never });
       const runPromise = h.run();
       // Step 1: 1 author. Drain warmup, then inject samples in dwell window.
       await vi.advanceTimersByTimeAsync(11);
@@ -69,7 +84,7 @@ describe('Harness.run sweep', () => {
 
 describe('Harness breakage thresholds', () => {
   it('flags a step when p95 exceeds break.p95Ms', async () => {
-    StubAuthor.instances = [];
+    resetStubs();
     vi.useFakeTimers();
     const dir = mkdtempSync(join(tmpdir(), 'h-'));
     try {
@@ -79,7 +94,7 @@ describe('Harness breakage thresholds', () => {
         breakP95Ms: 50,
       });
       const h = new Harness(cfg, new StubScraper() as never,
-                            { authorFactory: () => new StubAuthor() as never });
+                            { authorFactory: (o) => new StubAuthor(o.authorName) as never });
       const p = h.run();
       await vi.advanceTimersByTimeAsync(2);
       StubAuthor.instances.forEach((a) => a.inject(100, 10));
@@ -92,7 +107,7 @@ describe('Harness breakage thresholds', () => {
   });
 
   it('continues past breakage by default (action=continue)', async () => {
-    StubAuthor.instances = [];
+    resetStubs();
     vi.useFakeTimers();
     const dir = mkdtempSync(join(tmpdir(), 'h-'));
     try {
@@ -102,7 +117,7 @@ describe('Harness breakage thresholds', () => {
         breakP95Ms: 50,
       });
       const h = new Harness(cfg, new StubScraper() as never,
-                            { authorFactory: () => new StubAuthor() as never });
+                            { authorFactory: (o) => new StubAuthor(o.authorName) as never });
       const p = h.run();
       for (let i = 0; i < 2; i++) {
         await vi.advanceTimersByTimeAsync(2);
@@ -111,6 +126,66 @@ describe('Harness breakage thresholds', () => {
       }
       const report = await p;
       expect(report.steps).toHaveLength(2);
+    } finally {
+      rmSync(dir, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('Harness lurkers', () => {
+  it('spawns cfg.lurkers connected-but-idle authors at run start', async () => {
+    resetStubs();
+    vi.useFakeTimers();
+    const dir = mkdtempSync(join(tmpdir(), 'h-'));
+    try {
+      const cfg = makeConfig({
+        outDir: dir,
+        lurkers: 3,
+        sweep: {axis: 'authors', min: 1, max: 1, step: 1, warmupMs: 1, dwellMs: 10},
+      });
+      const h = new Harness(cfg, new StubScraper() as never,
+                            { authorFactory: (o) => new StubAuthor(o.authorName) as never });
+      const p = h.run();
+      await vi.advanceTimersByTimeAsync(15);
+      await p;
+      // 3 lurkers + 1 author
+      expect(StubAuthor.instances.length).toBe(4);
+      const lurkers = StubAuthor.instances.filter((a) => a.authorName.startsWith('l'));
+      const authors = StubAuthor.instances.filter((a) => a.authorName.startsWith('a'));
+      expect(lurkers).toHaveLength(3);
+      expect(authors).toHaveLength(1);
+      // Lurkers connect but never start() — they only hold sockets
+      lurkers.forEach((l) => expect(l.started).toBe(false));
+      authors.forEach((a) => expect(a.started).toBe(true));
+      // All stopped at cleanup
+      [...lurkers, ...authors].forEach((a) => expect(a.stopped).toBe(true));
+    } finally {
+      rmSync(dir, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('Harness allSettled spawn', () => {
+  it('records failed author connects as droppedAuthors and keeps sweeping', async () => {
+    resetStubs();
+    StubAuthor.failNext = 1; // first author of step 1 fails to connect
+    vi.useFakeTimers();
+    const dir = mkdtempSync(join(tmpdir(), 'h-'));
+    try {
+      const cfg = makeConfig({
+        outDir: dir,
+        sweep: {axis: 'authors', min: 2, max: 2, step: 2, warmupMs: 1, dwellMs: 10},
+      });
+      const h = new Harness(cfg, new StubScraper() as never,
+                            { authorFactory: (o) => new StubAuthor(o.authorName) as never });
+      const p = h.run();
+      await vi.advanceTimersByTimeAsync(15);
+      const report = await p;
+      expect(report.steps).toHaveLength(1);
+      expect(report.steps[0]!.droppedAuthors).toBe(1);
+      // The author that DID connect was the only one that contributed
+      const live = StubAuthor.instances.filter((a) => a.started);
+      expect(live).toHaveLength(1);
     } finally {
       rmSync(dir, {recursive: true, force: true});
     }


### PR DESCRIPTION
## Summary

Closes the two known follow-ups flagged in #94's body.

- **Lurkers** — `Config.lurkers` was wired through types/CLI/config but `Harness.run()` never spawned them. Now spawned once at run start with `Promise.allSettled`, named `l1..lN`, never `start()`'d (per spec section 3 they hold sockets and emit nothing), stopped at cleanup.
- **Promise.allSettled** — per-step author spawn was sequential `await a.connect()`. A single connect failure aborted the whole sweep. Now `Promise.allSettled`: failed connects bump that step's `droppedAuthors` and the sweep continues. Lurker connect failures roll into the first step's `droppedAuthors` so the curve's first row reflects total concurrency shortfall, not a silent miss.

48 tests green (was 46) — two new tests pin the behaviours: `Harness lurkers` asserts 3 connected-but-idle lurkers + 1 active author + cleanup; `Harness allSettled spawn` injects a stub connect failure and asserts `droppedAuthors === 1` with the sweep completing.

## Test Plan

- [ ] CI: `pnpm test` step passes (48 tests).
- [ ] CI: existing legacy `runnerLoadTest.sh 25 50` against ether/etherpad still exits 0.
- [ ] CI: sweep integration step still produces a valid report.
- [ ] Local: \`etherpad-loadtest --sweep authors=2..4:step=2:dwell=2s --lurkers 3 --report ./out\` connects 3 lurkers + the sweep's authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)