### PR TITLE
ci(scaling-dive): pin pnpm version

### DIFF
--- a/.github/workflows/scaling-dive.yml
+++ b/.github/workflows/scaling-dive.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
+          version: 11.1.2  # matches etherpad core's packageManager pin; required because no package.json sits at the runner root in this workflow
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
Trivial follow-up to #96 — the dive workflow needs an explicit pnpm version because neither repo sits at the runner root for auto-detection. Pinned to 11.1.2 to match core's `packageManager`. Run 25934227910 failed at every matrix entry's 'Install pnpm' step with 'No pnpm version is specified.'