### PR TITLE
fix(sim): Scraper allowlist + Reporter CSV match real metric names

### DIFF
--- a/src/sim/config.ts
+++ b/src/sim/config.ts
@@ -29,16 +29,24 @@ export interface ConfigInput {
   force?: boolean;
 }
 
+// Default allowlist. Names come from what etherpad core's /stats/prometheus
+// actually emits: a few etherpad_-prefixed custom rows plus the prom-client
+// default metrics (process_cpu_*, process_resident_memory_bytes,
+// nodejs_eventloop_lag_*). Names are matched as prefixes against the base
+// metric name (before `{labels}`).
 const DEFAULT_KEEP = [
-  'nodejs_cpu_gauge',
-  'nodejs_eventloop_latency_gauge',
-  'nodejs_memory_process_gauge',
-  'nodejs_gc_gauge',
-  'etherpad_total_users',
-  'etherpad_active_pads',
-  'etherpad_pad_users',
-  'etherpad_changeset_apply_duration_seconds',
-  'etherpad_socket_emits_total',
+  // etherpad custom (active + planned via ether/etherpad#7762)
+  'etherpad_',
+  // prom-client defaults
+  'process_cpu_',                  // process_cpu_user_seconds_total, _system_seconds_total
+  'process_resident_memory_bytes', // RSS
+  'process_heap_bytes',
+  'nodejs_eventloop_lag',          // nodejs_eventloop_lag_seconds + _p50/_p95/_p99/_max
+  'nodejs_heap_size',
+  'nodejs_active_handles',
+  'nodejs_gc_duration_seconds',
+  // ueberdb
+  'ueberdb_stats',
 ];
 
 const requireNonNeg = (name: string, v: number | undefined): void => {

--- a/src/sim/reporter.ts
+++ b/src/sim/reporter.ts
@@ -69,8 +69,13 @@ export class Reporter {
     };
     const rows = this.steps.map((s) => {
       const g = s.snapshot.gauges;
-      const rssBytes = g['nodejs_memory_process_gauge{type=rss}'];
+      // CSV column → /stats/prometheus row mapping. Names come from prom-client's
+      // collectDefaultMetrics output that etherpad core actually emits.
+      const rssBytes = g['process_resident_memory_bytes'];
       const rssMb = rssBytes !== undefined ? Math.round(rssBytes / 1_048_576) : undefined;
+      const evloopP95s = g['nodejs_eventloop_lag_p95_seconds'];
+      const evloopP95Ms = evloopP95s !== undefined ? Math.round(evloopP95s * 1000) : undefined;
+      const cpuUserS = g['process_cpu_user_seconds_total'];
       return [
         s.step,
         fmt(s.latencyMs.p50),
@@ -78,8 +83,8 @@ export class Reporter {
         fmt(s.latencyMs.p99),
         fmt(s.latencyMs.max),
         fmt(s.throughputCsps),
-        cell(g, 'nodejs_cpu_gauge{type=user}'),
-        cell(g, 'nodejs_eventloop_latency_gauge{type=p95}'),
+        fmt(cpuUserS),
+        fmt(evloopP95Ms),
         fmt(rssMb),
         cell(g, 'etherpad_total_users'),
         s.errors,
@@ -101,9 +106,11 @@ export class Reporter {
     ];
     const rows = this.steps.map((s) => {
       const g = s.snapshot.gauges;
-      const el = g['nodejs_eventloop_latency_gauge{type=p95}'] ?? '';
-      const cpu = g['nodejs_cpu_gauge{type=user}'] ?? '';
-      return `| ${s.step} | ${s.latencyMs.p50} | ${s.latencyMs.p95} | ${s.latencyMs.p99} | ${el} | ${cpu} | ${s.errors} | ${s.breakageFlags.join('|')} |`;
+      const elS = g['nodejs_eventloop_lag_p95_seconds'];
+      const elMs = elS !== undefined ? Math.round(elS * 1000) : '';
+      const cpuS = g['process_cpu_user_seconds_total'];
+      const cpu = cpuS !== undefined ? cpuS.toFixed(2) : '';
+      return `| ${s.step} | ${s.latencyMs.p50} | ${s.latencyMs.p95} | ${s.latencyMs.p99} | ${elMs} | ${cpu} | ${s.errors} | ${s.breakageFlags.join('|')} |`;
     });
 
     // Sparkline of p95

--- a/tests/sim/config.test.ts
+++ b/tests/sim/config.test.ts
@@ -14,7 +14,7 @@ describe('makeConfig defaults', () => {
     expect(c.break.action).toBe('continue');
     expect(c.scrape.intervalMs).toBe(1000);
     expect(c.scrape.url).toBe('http://127.0.0.1:9001/stats/prometheus');
-    expect(c.scrape.keep).toContain('nodejs_eventloop_latency_gauge');
+    expect(c.scrape.keep).toContain('nodejs_eventloop_lag');
   });
 
   it('derives scrape url from sutUrl when not overridden', () => {


### PR DESCRIPTION
## Summary

First real dive run (25934713423) exposed that the Scraper's default allowlist filtered out every server-side metric — CSV \`cpu_user\` / \`evloop_p95_ms\` / \`rss_mb\` were empty across all three lever reports. Root cause: the allowlist referenced \`nodejs_cpu_gauge\` / \`nodejs_eventloop_latency_gauge\` / \`nodejs_memory_process_gauge\` (defined in \`etherpad-lite/src/node/metrics.ts\` but never registered with the Prometheus register), instead of prom-client's actual \`collectDefaultMetrics\` output: \`process_cpu_user_seconds_total\`, \`nodejs_eventloop_lag_p95_seconds\`, \`process_resident_memory_bytes\`.

Two changes:

1. **\`src/sim/config.ts\`** — DEFAULT_KEEP now prefix-matches the real names. Single \`etherpad_\` prefix covers all current and future etherpad_ rows (including the three added in [ether/etherpad#7762](https://github.com/ether/etherpad/pull/7762)).
2. **\`src/sim/reporter.ts\`** — CSV column lookups updated. Column **names** stay stable (cpu_user, evloop_p95_ms, rss_mb); only the underlying gauge keys change. Seconds-to-ms and bytes-to-MB conversions preserved.

48 tests green. Will trigger a fresh dive after merge to confirm the columns populate.

## Test Plan

- [ ] CI: \`pnpm test\` passes.
- [ ] CI: legacy + sweep integration steps still green.
- [ ] After merge: trigger Scaling dive, confirm \`report.csv\` has non-empty \`cpu_user\`, \`evloop_p95_ms\`, \`rss_mb\` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)