### PR TITLE
revert: drop fanout-debounce matrix entry (the lever doesn't help)

### DIFF
--- a/.github/workflows/scaling-dive.yml
+++ b/.github/workflows/scaling-dive.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lever: [baseline, websocket-only, nodemem, fanout-debounce]
+        lever: [baseline, websocket-only, nodemem]
 
     env:
       PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
@@ -118,12 +118,6 @@ jobs:
             nodemem)
               # No settings change; NODE_OPTIONS is set when launching below.
               echo "applied via NODE_OPTIONS"
-              ;;
-            fanout-debounce)
-              # Lever 3: coalesce per-pad fan-out within a 50ms window
-              # (requires ether/etherpad#7766 in the checked-out core_ref).
-              sed -i '/"loadTest": true,/a\  "fanoutDebounceMs": 50,' settings.json
-              grep fanoutDebounceMs settings.json || { echo "fanoutDebounceMs not present — core must include #7766"; exit 1; }
               ;;
             *)
               echo "unknown lever: ${{ matrix.lever }}" >&2


### PR DESCRIPTION
Removes the fanout-debounce lever added in #102. Scored against [run 25940112728](https://github.com/ether/etherpad-load-test/actions/runs/25940112728); confirmed it doesn't reduce emit volume. ether/etherpad#7766 closed. Keeps the 60-min job timeout from the same PR.