### PR TITLE
feat(scaling-dive): new-changes-batch matrix entry

### DIFF
--- a/.github/workflows/scaling-dive.yml
+++ b/.github/workflows/scaling-dive.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lever: [baseline, websocket-only, nodemem]
+        lever: [baseline, websocket-only, nodemem, new-changes-batch]
 
     env:
       PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
@@ -118,6 +118,12 @@ jobs:
             nodemem)
               # No settings change; NODE_OPTIONS is set when launching below.
               echo "applied via NODE_OPTIONS"
+              ;;
+            new-changes-batch)
+              # Lever 3b: pack multi-rev fan-out into one NEW_CHANGES_BATCH emit
+              # per recipient. Requires the core_ref to include ether/etherpad#7768.
+              sed -i '/"loadTest": true,/a\  "newChangesBatch": true,' settings.json
+              grep newChangesBatch settings.json || { echo "newChangesBatch not present — core must include #7768"; exit 1; }
               ;;
             *)
               echo "unknown lever: ${{ matrix.lever }}" >&2


### PR DESCRIPTION
Scores [ether/etherpad#7768](https://github.com/ether/etherpad/pull/7768) once it merges. Sets `settings.newChangesBatch: true` via sed-append, mirroring the scalingDiveMetrics pattern.