### PR TITLE
feat(harness): forward-compat with engine.io WS packing + dive lever

### DIFF
--- a/.github/workflows/scaling-dive.yml
+++ b/.github/workflows/scaling-dive.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lever: [baseline, websocket-only, nodemem, new-changes-batch]
+        lever: [baseline, websocket-only, nodemem, new-changes-batch, engine-packing]
 
     env:
       PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
@@ -133,6 +133,15 @@ jobs:
               # per recipient. Requires the core_ref to include ether/etherpad#7768.
               sed -i '/"loadTest": true,/a\  "newChangesBatch": true,' settings.json
               grep newChangesBatch settings.json || { echo "newChangesBatch not present — core must include #7768"; exit 1; }
+              ;;
+            engine-packing)
+              # Lever 8: engine.io WS transport-level packing. When the
+              # engine.io socket has >1 packets buffered, send them as ONE
+              # WS frame containing the payload-encoded multi-packet
+              # bundle instead of one frame per packet. Requires the
+              # core_ref to include feat/engine-io-ws-packing.
+              sed -i '/"loadTest": true,/a\  "enginePacking": true,' settings.json
+              grep enginePacking settings.json || { echo "enginePacking not present — core must include feat/engine-io-ws-packing"; exit 1; }
               ;;
             *)
               echo "unknown lever: ${{ matrix.lever }}" >&2

--- a/src/sim/author.ts
+++ b/src/sim/author.ts
@@ -1,6 +1,14 @@
 import {EventEmitter} from 'node:events';
 import {connect} from 'etherpad-cli-client';
 import type {Sample} from './types.js';
+import {installEnginePackingClientPatch} from './engine-packing-client-patch.js';
+
+// Forward-compat with servers that have settings.enginePacking enabled
+// (ether/etherpad#7756 lever 8). Applied once at module load so any Author
+// constructed afterwards uses the patched engine.io-client transport.
+// Safe against legacy servers — a single-packet frame contains no `\x1e`,
+// so the patch's discriminator preserves the original code path.
+installEnginePackingClientPatch();
 
 export interface PadLike extends EventEmitter {
   append(s: string): void;

--- a/src/sim/engine-packing-client-patch.ts
+++ b/src/sim/engine-packing-client-patch.ts
@@ -1,0 +1,70 @@
+// Forward-compatible client-side patch for engine.io's WebSocket transport
+// (ether/etherpad#7756 lever 8). Recognises payload-encoded WS frames sent
+// by a server that enables `settings.enginePacking`.
+//
+// Engine.io's base transport calls `onData(data)` per incoming WS frame and
+// runs `decodePacket(data, binaryType)` on it. With server-side packing
+// enabled, a single WS frame can carry multiple engine.io packets joined
+// by the record separator (`\x1e`, U+001E), the same wire format the
+// polling transport uses. This patch detects the separator and routes
+// through `decodePayload` when present.
+//
+// Always on (no setting). A single-packet frame never legitimately
+// contains `\x1e`: engine.io packet type bytes are '0'-'6' or empty for
+// binary, and JSON serialises raw `\x1e` to the escape sequence
+// ``. So the separator check is a safe discriminator.
+//
+// Idempotent. Patches the prototype once; safe to call from multiple init
+// paths.
+//
+// We reach into the pnpm store via the canonical path under
+// `node_modules/.pnpm/` so we patch the SAME engine.io-client module
+// instance the bundled socket.io-client uses (pnpm symlinks resolve to the
+// same module object).
+
+import {createRequire} from 'node:module';
+import path from 'node:path';
+
+let installed = false;
+
+const HARNESS_ROOT = path.resolve(__dirname, '../..');
+const ENGINE_IO_CLIENT_PATH = path.join(
+  HARNESS_ROOT,
+  'node_modules/.pnpm/engine.io-client@6.6.4/node_modules/engine.io-client/build/cjs/transport.js',
+);
+const ENGINE_IO_PARSER_PATH = path.join(
+  HARNESS_ROOT,
+  'node_modules/.pnpm/engine.io-parser@5.2.3/node_modules/engine.io-parser/build/cjs/index.js',
+);
+
+const req = createRequire(__filename);
+
+export const installEnginePackingClientPatch = (): void => {
+  if (installed) return;
+  installed = true;
+
+  let TransportProto: {onData?: (d: unknown) => void} & Record<string, unknown>;
+  let decodePayload: (data: string, binaryType?: string) => Array<unknown>;
+  try {
+    TransportProto = req(ENGINE_IO_CLIENT_PATH).Transport.prototype;
+    decodePayload = req(ENGINE_IO_PARSER_PATH).decodePayload;
+  } catch (err: any) {
+    console.error(`[engine-packing-client-patch] cannot resolve engine.io-client/parser: ${err && err.message || err}`);
+    return;
+  }
+  if (typeof TransportProto.onData !== 'function' || typeof decodePayload !== 'function') {
+    console.error('[engine-packing-client-patch] engine.io-client shape unexpected; skipping');
+    return;
+  }
+
+  const original = TransportProto.onData as (this: unknown, data: unknown) => void;
+  const SEPARATOR = String.fromCharCode(30);
+
+  TransportProto.onData = function (this: {socket?: {binaryType?: string}; onPacket: (p: unknown) => void}, data: unknown) {
+    if (typeof data !== 'string' || data.indexOf(SEPARATOR) === -1) {
+      return original.call(this, data);
+    }
+    const packets = decodePayload(data, this.socket?.binaryType ?? 'nodebuffer');
+    for (const packet of packets) this.onPacket(packet);
+  };
+};


### PR DESCRIPTION
Two changes for [ether/etherpad#7756](https://github.com/ether/etherpad/issues/7756) lever 8 / [ether/etherpad#7772](https://github.com/ether/etherpad/pull/7772):

1. **engine.io-client patch** — `src/sim/engine-packing-client-patch.ts` monkey-patches the engine.io-client Transport prototype so `onData` detects payload-encoded frames (`\x1e` record separator) and routes through `decodePayload`. Single-packet frames keep the legacy path. Always-on; the separator is a safe discriminator (engine.io packet type bytes are '0'-'6' or empty for binary, JSON escapes raw `\x1e` to `\u001e`). Patches the pnpm-store path so all socket.io-client instances share the patched prototype.

2. **`engine-packing` matrix entry** in `.github/workflows/scaling-dive.yml` — sets `settings.enginePacking: true` and runs the dive against the SUT. Requires `core_ref=feat/engine-io-ws-packing`.

48 tests still green. Build clean.