### PR TITLE
fix(ci): restore sweep integration test against hardened core (cli-client 4.0.3 + rate-limit)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -78,6 +78,14 @@ jobs:
           # The previous step (runnerLoadTest.sh) tore Etherpad down, so
           # bring a minimal one back up just for the sweep integration test.
           cd ./etherpad
+          # The sweep drives 2..4 authors from a single IP (127.0.0.1). Core's
+          # default commitRateLimiting is 10 changes/s/IP, so the 4-author step
+          # (~20 changes/s) trips the limiter; a rate-limited USER_CHANGES never
+          # gets an ACCEPT_COMMIT, which stalls the cli-client's in-flight slot
+          # and zeroes out that step's latency samples. Raise the cap for the
+          # SUT so we measure throughput, not the rate limiter (mirrors the
+          # importExportRateLimiting bump runnerLoadTest.sh already applies).
+          sed -e '/^ *"commitRateLimiting":/,/^ *\}/ s/"points":.*/"points": 1000000/' -i settings.json
           (cd src && pnpm run prod &)
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:9001/ >/dev/null && break

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Check out etherpad-load-test
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: ./loadtest
 
       - name: Check out Etherpad core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ether/etherpad-lite
           path: ./etherpad

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -85,7 +85,8 @@ jobs:
           # and zeroes out that step's latency samples. Raise the cap for the
           # SUT so we measure throughput, not the rate limiter (mirrors the
           # importExportRateLimiting bump runnerLoadTest.sh already applies).
-          sed -e '/^ *"commitRateLimiting":/,/^ *\}/ s/"points":.*/"points": 1000000/' -i settings.json
+          sed -e '/^ *"commitRateLimiting":/,/^ *\}/ s!"points":[^,]*!"points": 1000000!' -i settings.json
+          grep -q '"points": 1000000' settings.json  # fail fast if the limiter wasn't raised
           (cd src && pnpm run prod &)
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:9001/ >/dev/null && break

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/cpu-profile.yml
+++ b/.github/workflows/cpu-profile.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout etherpad-load-test
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: ./loadtest
 
       - name: Checkout etherpad core (${{ inputs.core_ref }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ether/etherpad
           ref: ${{ inputs.core_ref }}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v4
         with:
@@ -56,7 +56,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scaling-dive.yml
+++ b/.github/workflows/scaling-dive.yml
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout etherpad-load-test
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: ./loadtest
 
       - name: Checkout etherpad core (${{ inputs.core_ref }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ether/etherpad
           ref: ${{ inputs.core_ref }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "contributors": [],
   "dependencies": {
-    "etherpad-cli-client": "^4.0.2",
+    "etherpad-cli-client": "^4.0.3",
     "hdr-histogram-js": "^3.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       etherpad-cli-client:
-        specifier: ^4.0.2
-        version: 4.0.2
+        specifier: ^4.0.3
+        version: 4.0.3
       hdr-histogram-js:
         specifier: ^3.0.1
         version: 3.0.1
@@ -619,8 +619,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etherpad-cli-client@4.0.2:
-    resolution: {integrity: sha512-oAyJxJj4UH0AAEmMPpMiTHKd2IT14OWnKaPzWTqLh3BJ8nyEv/IAMA5scAGjet0xKNERm+k7VSnfeJQvN4adKQ==}
+  etherpad-cli-client@4.0.3:
+    resolution: {integrity: sha512-nQt5FxpmfQHwJ546TJXKMT4fMIS1crvU+NvHAypfboHTsbFQMIPOu4ZANSirRzE1lYnH4APUBDwMQqlKeQt9rw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1562,7 +1562,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etherpad-cli-client@4.0.2:
+  etherpad-cli-client@4.0.3:
     dependencies:
       socket.io-client: 4.8.3
       superagent: 10.3.0


### PR DESCRIPTION
## Problem

Backend-tests CI has been **red on every PR since ~2026-05-19**; the last green run was [#111](https://github.com/ether/etherpad-load-test/actions) on 2026-05-16. The `Run sweep integration test` step fails with:

```
AssertionError: expected 0 to be greater than 0
 ❯ tests/sim/integration.test.ts:35:35   // expect(s.latencyMs.count).toBeGreaterThan(0)
```

This surfaced while looking at #121 (the `actions/checkout` 4→7 bump) — that bump is fine; its checkout steps pass. The red check is an unrelated, pre-existing, repo-wide failure.

## Root cause (not in this repo)

`ether/etherpad#7773` — *"harden: reject USER_CHANGES inserts without an author attribute"* — merged **2026-05-16 17:23**, immediately after the last green run. It tightened server-side changeset validation (reject inserts with no `author` attribute; reject changesets that strand the trailing `\n`) and **bumped its own `etherpad-cli-client` dependency to `4.0.3`** to comply.

This repo was still pinned to `etherpad-cli-client` **4.0.2**, whose `append()` splices at `text.length` (after the trailing `\n`) with an empty apool and no author attribute — exactly the two shapes #7773 now rejects as `badChangeset`. Result: **zero `ACCEPT_COMMIT`s**, so every sweep step records `latencyMs.count === 0` and the test fails.

## Fix (two parts, both verified against a local core build at develop HEAD)

1. **Bump `etherpad-cli-client` 4.0.2 → 4.0.3** — sends author-attributed inserts and preserves the trailing newline.
2. **Raise `commitRateLimiting` on the SUT** in the sweep step. The sweep drives 2..4 authors from a single IP; core's default 10 changes/s/IP rate-limits the 4-author step (~20/s), and a rate-limited `USER_CHANGES` never gets an `ACCEPT_COMMIT`, stalling the 4.0.3 client's in-flight slot → `count=0`, `errors=4`. Mirrors the `importExportRateLimiting` bump `runnerLoadTest.sh` already applies.

## Verification

Built `ether/etherpad` at develop HEAD (includes #7773) and ran the sweep against it:

| client | rate limit | step=2 | step=4 |
|--------|-----------|--------|--------|
| 4.0.2 | default | count=0 ❌ | count=0 ❌ |
| 4.0.3 | default (10/s) | count=20 ✅ | count=0, errors=4 ❌ |
| **4.0.3** | **raised** | **count=20 ✅** | **count=40 ✅** |

`pnpm test:integration` passes end-to-end with both changes; `pnpm test` (48 tests) green.

## Follow-up (separate)

`etherpad-cli-client` 4.0.3 permanently stalls its in-flight slot when a `USER_CHANGES` is rate-limited (no `ACCEPT_COMMIT` ever clears it). Out of scope here, but worth hardening in that client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)